### PR TITLE
Fix multiple group issue

### DIFF
--- a/groupprice.civix.php
+++ b/groupprice.civix.php
@@ -146,7 +146,7 @@ function _groupprice_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         } elseif (is_dir($path)) {
           $todos[] = $path;
         }

--- a/groupprice.php
+++ b/groupprice.php
@@ -124,18 +124,18 @@ function groupprice_civicrm_buildAmount($pageType, &$form, &$amount) {
         }
       }
 
-      $hide = FALSE;
+      $hide = TRUE;
       foreach ($acl['gids'] as $gid) {
         if (!$acl['negate']) {
           // Only members of the group can see it.
-          if (!array_key_exists($gid, $userGids)) {
-            $hide = TRUE;
+          if (array_key_exists($gid, $userGids)) {
+            $hide = FALSE;
           }
         }
         else {
           // Negated filtering. Only non-members can see it.
-          if (array_key_exists($gid, $userGids)) {
-            $hide = TRUE;
+          if (!array_key_exists($gid, $userGids)) {
+            $hide = FALSE;
           }
         }
       }


### PR DESCRIPTION
This is an updated PR to the closed PR #15. This PR still adds in multiple checks for a contact, but also flips some logic on whether the contact is in a group or not.

The group check swap was because of an issue where someone could be in multiple groups. Since we know at this point an ACL exists, we force the option to be hidden. Then if someone is in one of any groups assigned to the ACL, then it changes it to be visible.